### PR TITLE
Fixed description field in method responses

### DIFF
--- a/src/metadata/methodGenerator.ts
+++ b/src/metadata/methodGenerator.ts
@@ -109,7 +109,7 @@ export class MethodGenerator {
                 status = decorator.arguments[0];
             }
             if (decorator.arguments.length > 1 && decorator.arguments[1]) {
-                description = (decorator.arguments[1] as any).text;
+                description = decorator.arguments[1] as any;
             }
             if (decorator.arguments.length > 2 && decorator.arguments[2]) {
                 const argument = decorator.arguments[2] as any;

--- a/test/data/apis.ts
+++ b/test/data/apis.ts
@@ -22,6 +22,7 @@ interface Person {
 @Path('mypath')
 @swagger.Tags('My Services')
 export class MyService {
+    @Response<string>('default', 'Error')
     @GET
     @Accept('text/html')
     test( ): string {


### PR DESCRIPTION
When using the `@Response` decorator for responses other than status=200 the second argument, which is the description argument, is meant to be a string.  However, the generator was expecting there to be a "text" field on that argument.  My update simply removes that from the generator and instead assumes the argument is a string.  I also added a `@Response` decorator to the apis.ts test data file.