### PR TITLE
support object literals in type definitions

### DIFF
--- a/src/metadata/metadataGenerator.ts
+++ b/src/metadata/metadataGenerator.ts
@@ -142,6 +142,10 @@ export interface ReferenceType extends Type {
     additionalProperties?: Property[];
 }
 
+export interface ObjectType extends Type {
+    properties: Property[];
+}
+
 export interface ArrayType extends Type {
     elementType: Type;
 }

--- a/src/metadata/resolveType.ts
+++ b/src/metadata/resolveType.ts
@@ -1,5 +1,5 @@
 import * as ts from 'typescript';
-import { MetadataGenerator, Type, EnumerateType, ReferenceType, ArrayType, Property } from './metadataGenerator';
+import { MetadataGenerator, Type, EnumerateType, ReferenceType, ObjectType, ArrayType, Property } from './metadataGenerator';
 import { getDecoratorName } from '../utils/decoratorUtils';
 import * as _ from 'lodash';
 
@@ -32,6 +32,10 @@ export function resolveType(typeNode?: ts.TypeNode, genericTypeMap?: Map<String,
 
     if ((typeNode.kind === ts.SyntaxKind.UnionType) || (typeNode.kind === ts.SyntaxKind.AnyKeyword)) {
         return { typeName: 'object' };
+    }
+
+    if (typeNode.kind === ts.SyntaxKind.TypeLiteral) {
+        return getInlineObjectType(typeNode);
     }
 
     if (typeNode.kind !== ts.SyntaxKind.TypeReference) {
@@ -182,6 +186,14 @@ function getLiteralType(typeNode: ts.TypeNode): EnumerateType | undefined {
         enumMembers: unionTypes.map((unionNode: any) => unionNode.literal.text as string),
         typeName: 'enum',
     };
+}
+
+function getInlineObjectType(typeNode: ts.TypeNode): ObjectType {
+    const type: ObjectType = {
+        properties: getModelTypeProperties(typeNode),
+        typeName: ''
+    };
+    return type;
 }
 
 function getReferenceType(type: ts.EntityName, genericTypeMap?: Map<String, ts.TypeNode>, genericTypes?: ts.TypeNode[]): ReferenceType {

--- a/src/metadata/resolveType.ts
+++ b/src/metadata/resolveType.ts
@@ -386,7 +386,12 @@ function getModelTypeProperties(node: any, genericTypes?: ts.TypeNode[]): Proper
     if (node.kind === ts.SyntaxKind.TypeLiteral || node.kind === ts.SyntaxKind.InterfaceDeclaration) {
         const interfaceDeclaration = node as ts.InterfaceDeclaration;
         return interfaceDeclaration.members
-            .filter(member => member.kind === ts.SyntaxKind.PropertySignature)
+            .filter(member => {
+                if ((<any>member).type && (<any>member).type.kind === ts.SyntaxKind.FunctionType) {
+                    return false;
+                }
+                return member.kind === ts.SyntaxKind.PropertySignature;
+            })
             .map((member: any) => {
 
                 const propertyDeclaration = member as ts.PropertyDeclaration;

--- a/src/swagger/generator.ts
+++ b/src/swagger/generator.ts
@@ -1,6 +1,6 @@
 import { SwaggerConfig } from '../config';
 import {
-    Metadata, Type, ArrayType, ReferenceType, EnumerateType,
+    Metadata, Type, ArrayType, ObjectType, ReferenceType, EnumerateType,
     Property, Method, Parameter, ResponseType
 } from '../metadata/metadataGenerator';
 import { Swagger } from './swagger';
@@ -283,6 +283,11 @@ export class SpecGenerator {
             return swaggerType;
         }
 
+        const objectType = type as ObjectType;
+        if (objectType.properties) {
+            return this.getSwaggerTypeForObjectType(objectType);
+        }
+
         const arrayType = type as ArrayType;
         if (arrayType.elementType) {
             return this.getSwaggerTypeForArrayType(arrayType);
@@ -317,6 +322,10 @@ export class SpecGenerator {
         };
 
         return typeMap[type.typeName];
+    }
+
+    private getSwaggerTypeForObjectType(objectType: ObjectType): Swagger.Schema {
+        return { type: 'object', properties: this.buildProperties(objectType.properties) };
     }
 
     private getSwaggerTypeForArrayType(arrayType: ArrayType): Swagger.Schema {

--- a/test/data/apis.ts
+++ b/test/data/apis.ts
@@ -22,9 +22,9 @@ interface Person {
 @Path('mypath')
 @swagger.Tags('My Services')
 export class MyService {
-    @Response<string>('default', 'Error')
-    @Response<string>(400, 'The request format was incorrect.')
-    @Response<string>(500, 'There was an unexpected error.')
+    @swagger.Response<string>('default', 'Error')
+    @swagger.Response<string>(400, 'The request format was incorrect.')
+    @swagger.Response<string>(500, 'There was an unexpected error.')
     @GET
     @Accept('text/html')
     test( ): string {
@@ -172,7 +172,13 @@ export type SimpleHelloType = {
     greeting: string;
     arrayOfSomething: Something[];
 
+    /**
+     * Description for profile
+     */
     profile: {
+        /**
+         * Description for profile name
+         */
         name: string
     };
 

--- a/test/unit/definitions.spec.ts
+++ b/test/unit/definitions.spec.ts
@@ -55,5 +55,11 @@ describe('Definition generation', () => {
       expression = jsonata('definitions.SimpleHelloType.properties.profile.properties.name.description');
       expect(expression.evaluate(spec)).to.eq('Description for profile name');
     });
+
+    it('should ignore properties that are functions', () => {
+      const expression = jsonata('definitions.SimpleHelloType.properties.comparePassword');
+      // tslint:disable-next-line:no-unused-expression
+      expect(expression.evaluate(spec)).to.not.exist;
+    });
   });
 });

--- a/test/unit/definitions.spec.ts
+++ b/test/unit/definitions.spec.ts
@@ -44,5 +44,16 @@ describe('Definition generation', () => {
       const expression = jsonata('definitions.SimpleHelloType.properties.greeting.description');
       expect(expression.evaluate(spec)).to.eq('Description for greeting property');
     });
+
+    it('should generate nested object types in definitions', () => {
+      let expression = jsonata('definitions.SimpleHelloType.properties.profile.type');
+      expect(expression.evaluate(spec)).to.eq('object');
+      expression = jsonata('definitions.SimpleHelloType.properties.profile.description');
+      expect(expression.evaluate(spec)).to.eq('Description for profile');
+      expression = jsonata('definitions.SimpleHelloType.properties.profile.properties.name.type');
+      expect(expression.evaluate(spec)).to.eq('string');
+      expression = jsonata('definitions.SimpleHelloType.properties.profile.properties.name.description');
+      expect(expression.evaluate(spec)).to.eq('Description for profile name');
+    });
   });
 });


### PR DESCRIPTION
Previously, type properties that were objects needed to be references to another type. This change adds definition generation support for inline object literals.

In the following example, `profile` and `profile.name` will now be correctly generated in the spec:
```
type SimpleHelloType = {
    greeting: string;
    arrayOfSomething: Something[];
    profile: {
        name: string
    };
};
```

This PR also adds a small change to ignore properties that are functions. Instead of crashing the generator, they are now silently ignored.