### PR TITLE
fix definition references for properties (regression)

### DIFF
--- a/src/swagger/generator.ts
+++ b/src/swagger/generator.ts
@@ -283,11 +283,6 @@ export class SpecGenerator {
             return swaggerType;
         }
 
-        const objectType = type as ObjectType;
-        if (objectType.properties) {
-            return this.getSwaggerTypeForObjectType(objectType);
-        }
-
         const arrayType = type as ArrayType;
         if (arrayType.elementType) {
             return this.getSwaggerTypeForArrayType(arrayType);
@@ -298,8 +293,13 @@ export class SpecGenerator {
             return this.getSwaggerTypeForEnumType(enumType);
         }
 
-        const refType = this.getSwaggerTypeForReferenceType(type as ReferenceType);
-        return refType;
+        const refType = type as ReferenceType;
+        if (refType.properties && refType.description !== undefined) {
+            return this.getSwaggerTypeForReferenceType(type as ReferenceType);
+        }
+
+        const objectType = type as ObjectType;
+        return this.getSwaggerTypeForObjectType(objectType);
     }
 
     private getSwaggerTypeForPrimitiveType(type: Type) {

--- a/test/unit/definitions.spec.ts
+++ b/test/unit/definitions.spec.ts
@@ -36,6 +36,10 @@ describe('Definition generation', () => {
       expect(expression.evaluate(spec)).to.eq('There was an unexpected error.');
     });
 
+    it('should generate a definition with a referenced type', () => {
+      const expression = jsonata('definitions.Person.properties.address."$ref"');
+      expect(expression.evaluate(spec)).to.eq('#/definitions/Address');
+    });
   });
 
   describe('TypeEndpoint', () => {


### PR DESCRIPTION
#20 broke type definition references from properties of other definitions. Instead, it duplicated the model of the referenced type inline. This PR fixes that regression and adds a test for it.

### Example
Pre-#20 and with this PR:
```
ErrorResponseBody:
    description: ""
    properties:
        error:
            $ref: '#/definitions/ErrorParams'
    type: object
    required:
        - error
```
Regression from #20:
```
ErrorResponseBody:
    description: ""
    properties:
        error:
            type: object
            properties:
                description:
                    type: string
                    description: ""
                info:
                    type: string
                    description: ""
                body:
                    type: object
                    description: ""
            description: ""
    type: object
    required:
        - error
```