### PR TITLE
add number format decorators for properties and parameters

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -179,6 +179,39 @@ class PeopleService {
 A Default produces is already created in swagger documentation from the method return analisys. 
 You can use this decorator to override this default produces.
 
+#### @IsInt, @IsLong, @IsFloat, @IsDouble
+
+Document the type of a `number` property or parameter in generated swagger docs.
+If no decorator is present, the `number` type defaults to `double` format.
+
+```typescript
+class Person {
+    @IsInt id: number;
+}
+
+@Path('people')
+class PeopleService {
+    @Path(':id')
+    @GET
+    getById(@PathParam('id') @IsLong id: number) {
+        // ...
+    }
+}
+```
+
+Because decorators don't work on type and interface properties, this can also be specified as a JSDoc tag.
+
+```typescript
+interface Person {
+    /**
+     * The person's id
+     * @IsInt
+     */
+    id: number;
+}
+```
+
+
 ### SwaggerConfig.json 
 
 The swagger config file supports the following properties: 

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -81,3 +81,32 @@ export function Security(name: string, scopes?: string[]): any {
 export function Produces(...values: string[]): any {
   return () => { return; };
 }
+
+/**
+ * Document the type of a property or parameter as `integer ($int32)` in generated swagger docs
+ */
+export function IsInt(target: any, propertyKey: string, parameterIndex?: number) {
+  return;
+}
+
+/**
+ * Document the type of a property or parameter as `integer ($int64)` in generated swagger docs
+ */
+export function IsLong(target: any, propertyKey: string, parameterIndex?: number) {
+  return;
+}
+
+/**
+ * Document the type of a property or parameter as `number ($float)` in generated swagger docs
+ */
+export function IsFloat(target: any, propertyKey: string, parameterIndex?: number) {
+  return;
+}
+
+/**
+ * Document the type of a property or parameter as `number ($double)` in generated swagger docs.
+ * This is the default for `number` types without a specifying decorator.
+ */
+export function IsDouble(target: any, propertyKey: string, parameterIndex?: number) {
+  return;
+}

--- a/src/utils/jsDocUtils.ts
+++ b/src/utils/jsDocUtils.ts
@@ -24,11 +24,22 @@ export function isExistJSDocTag(node: ts.Node, tagName: string) {
 }
 
 function getJSDocTags(node: ts.Node, tagName: string) {
+    return getMatchingJSDocTags(node, t => t.tagName.text === tagName);
+}
+
+export function getFirstMatchingJSDocTagName(node: ts.Node, isMatching: (t: ts.JSDocTag) => boolean) {
+    const tags = getMatchingJSDocTags(node, isMatching);
+    if (!tags || !tags.length) { return; }
+
+    return tags[0].tagName.text;
+}
+
+function getMatchingJSDocTags(node: ts.Node, isMatching: (t: ts.JSDocTag) => boolean) {
     const jsDocs = (node as any).jsDoc as ts.JSDoc[];
     if (!jsDocs || !jsDocs.length) { return; }
 
     const jsDoc = jsDocs[0];
     if (!jsDoc.tags) { return; }
 
-    return jsDoc.tags.filter(t => t.tagName.text === tagName);
+    return jsDoc.tags.filter(isMatching);
 }

--- a/test/data/apis.ts
+++ b/test/data/apis.ts
@@ -201,3 +201,65 @@ export class TypeEndpoint {
         });
     }
 }
+
+export class PrimitiveClassModel {
+    /**
+     * An integer
+     */
+    @swagger.IsInt
+    int?: number;
+
+    @swagger.IsLong
+    long?: number;
+
+    @swagger.IsFloat
+    float?: number;
+
+    @swagger.IsDouble
+    double?: number;
+}
+
+export interface PrimitiveInterfaceModel {
+    /**
+     * An integer
+     * @IsInt
+     */
+    int?: number;
+
+    /**
+     * @IsLong
+     */
+    long?: number;
+
+    /**
+     * @IsFloat
+     */
+    float?: number;
+
+    /**
+     * @IsDouble
+     */
+    double?: number;
+}
+
+@Path('primitives')
+export class PrimitiveEndpoint {
+
+    @Path('/class')
+    @GET
+    getClass(): PrimitiveClassModel {
+        return new PrimitiveClassModel();
+    }
+
+    @Path('/interface')
+    @GET
+    testInterface(): PrimitiveInterfaceModel {
+        return {};
+    }
+
+    @Path(':id')
+    @GET
+    getById(@PathParam('id') @swagger.IsLong id: number) {
+        // ...
+    }
+}

--- a/test/unit/definitions.spec.ts
+++ b/test/unit/definitions.spec.ts
@@ -66,4 +66,85 @@ describe('Definition generation', () => {
       expect(expression.evaluate(spec)).to.not.exist;
     });
   });
+
+  describe('PrimitiveEndpoint', () => {
+    it('should generate integer type for @IsInt decorator declared on class property', () => {
+      let expression = jsonata('definitions.PrimitiveClassModel.properties.int.type');
+      expect(expression.evaluate(spec)).to.eq('integer');
+      expression = jsonata('definitions.PrimitiveClassModel.properties.int.format');
+      expect(expression.evaluate(spec)).to.eq('int32');
+      expression = jsonata('definitions.PrimitiveClassModel.properties.int.description');
+      expect(expression.evaluate(spec)).to.eq('An integer');
+    });
+
+    it('should generate integer type for @IsLong decorator declared on class property', () => {
+      let expression = jsonata('definitions.PrimitiveClassModel.properties.long.type');
+      expect(expression.evaluate(spec)).to.eq('integer');
+      expression = jsonata('definitions.PrimitiveClassModel.properties.long.format');
+      expect(expression.evaluate(spec)).to.eq('int64');
+      expression = jsonata('definitions.PrimitiveClassModel.properties.long.description');
+      expect(expression.evaluate(spec)).to.eq('');
+    });
+
+    it('should generate number type for @IsFloat decorator declared on class property', () => {
+      let expression = jsonata('definitions.PrimitiveClassModel.properties.float.type');
+      expect(expression.evaluate(spec)).to.eq('number');
+      expression = jsonata('definitions.PrimitiveClassModel.properties.float.format');
+      expect(expression.evaluate(spec)).to.eq('float');
+      expression = jsonata('definitions.PrimitiveClassModel.properties.float.description');
+      expect(expression.evaluate(spec)).to.eq('');
+    });
+
+    it('should generate number type for @IsDouble decorator declared on class property', () => {
+      let expression = jsonata('definitions.PrimitiveClassModel.properties.double.type');
+      expect(expression.evaluate(spec)).to.eq('number');
+      expression = jsonata('definitions.PrimitiveClassModel.properties.double.format');
+      expect(expression.evaluate(spec)).to.eq('double');
+      expression = jsonata('definitions.PrimitiveClassModel.properties.double.description');
+      expect(expression.evaluate(spec)).to.eq('');
+    });
+
+    it('should generate integer type for jsdoc @IsInt tag on interface property', () => {
+      let expression = jsonata('definitions.PrimitiveInterfaceModel.properties.int.type');
+      expect(expression.evaluate(spec)).to.eq('integer');
+      expression = jsonata('definitions.PrimitiveInterfaceModel.properties.int.format');
+      expect(expression.evaluate(spec)).to.eq('int32');
+      expression = jsonata('definitions.PrimitiveInterfaceModel.properties.int.description');
+      expect(expression.evaluate(spec)).to.eq('An integer');
+    });
+
+    it('should generate integer type for jsdoc @IsLong tag on interface property', () => {
+      let expression = jsonata('definitions.PrimitiveInterfaceModel.properties.long.type');
+      expect(expression.evaluate(spec)).to.eq('integer');
+      expression = jsonata('definitions.PrimitiveInterfaceModel.properties.long.format');
+      expect(expression.evaluate(spec)).to.eq('int64');
+      expression = jsonata('definitions.PrimitiveInterfaceModel.properties.long.description');
+      expect(expression.evaluate(spec)).to.eq('');
+    });
+
+    it('should generate number type for jsdoc @IsFloat tag on interface property', () => {
+      let expression = jsonata('definitions.PrimitiveInterfaceModel.properties.float.type');
+      expect(expression.evaluate(spec)).to.eq('number');
+      expression = jsonata('definitions.PrimitiveInterfaceModel.properties.float.format');
+      expect(expression.evaluate(spec)).to.eq('float');
+      expression = jsonata('definitions.PrimitiveInterfaceModel.properties.float.description');
+      expect(expression.evaluate(spec)).to.eq('');
+    });
+
+    it('should generate number type for jsdoc @IsDouble tag on interface property', () => {
+      let expression = jsonata('definitions.PrimitiveInterfaceModel.properties.double.type');
+      expect(expression.evaluate(spec)).to.eq('number');
+      expression = jsonata('definitions.PrimitiveInterfaceModel.properties.double.format');
+      expect(expression.evaluate(spec)).to.eq('double');
+      expression = jsonata('definitions.PrimitiveInterfaceModel.properties.double.description');
+      expect(expression.evaluate(spec)).to.eq('');
+    });
+
+    it('should generate number type decorated path params', () => {
+      let expression = jsonata('paths."/primitives/{id}".get.parameters[0].type');
+      expect(expression.evaluate(spec)).to.eq('integer');
+      expression = jsonata('paths."/primitives/{id}".get.parameters[0].format');
+      expect(expression.evaluate(spec)).to.eq('int64');
+    });
+  });
 });


### PR DESCRIPTION
Expand the existing support for number format decorators (e.g. `@IsInt`). This PR adds decorators for the consumer to use on class properties and method parameters. It also adds support for getting the number format from JSDoc tags to allow type and interface declarations to use this feature.