### PR TITLE
if @Response then override default behaviour

### DIFF
--- a/src/metadata/methodGenerator.ts
+++ b/src/metadata/methodGenerator.ts
@@ -33,7 +33,9 @@ export class MethodGenerator {
         const identifier = this.node.name as ts.Identifier;
         const type = resolveType(this.node.type, this.genericTypeMap);
         const responses = this.getMethodResponses();
-        responses.push(this.getMethodSuccessResponse(type));
+        if (0 === responses.length) {
+          responses.push(this.getMethodSuccessResponse(type));
+        }
 
         return {
             consumes: this.getDecoratorValues('Accept'),


### PR DESCRIPTION
This PR corrects the `@Response` annotation behaviour, that should never be overridden by the default method Response type which is the method return type.
@thiagobustamante 