### PR TITLE
fix $ref for model schema

### DIFF
--- a/src/swagger/generator.ts
+++ b/src/swagger/generator.ts
@@ -349,6 +349,6 @@ export class SpecGenerator {
     }
 
     private getSwaggerTypeForReferenceType(referenceType: ReferenceType): Swagger.Schema {
-        return { $ref: `#/definitions/${referenceType.typeName}` };
+        return { '$ref': `#/definitions/${referenceType.typeName}` };
     }
 }


### PR DESCRIPTION
At the moment the library generates swagger references like this:
```json
"responses": {
  "200": {
    "description": "Ok",
    "schema": {
      "": "#/definitions/ENOCResponseNodeNotesModel"
    }
  }
}
```
this PR fixes it giving the schema name property the correct name:
```
"responses": {
  "200": {
    "description": "Ok",
    "schema": {
      "$ref": "#/definitions/ENOCResponseNodeNotesModel"
    }
  }
}
```