### PR TITLE
read info object from swaggerConfig.json

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -92,4 +92,9 @@ export interface SwaggerConfig {
      * Possible values are `csv`, `ssv`, `tsv`, `pipes`, `multi`. If not specified, Swagger defaults to `csv`.
      */
     collectionFormat?: string;
+
+    /**
+     * Swagger Info block, if it exists will be used as Info section of the resulting swagger file.
+     */
+    info?: any;
 }

--- a/src/swagger/generator.ts
+++ b/src/swagger/generator.ts
@@ -59,11 +59,16 @@ export class SpecGenerator {
 
         if (this.config.consumes) { spec.consumes = this.config.consumes; }
         if (this.config.produces) { spec.produces = this.config.produces; }
-        if (this.config.description) { spec.info.description = this.config.description; }
-        if (this.config.license) { spec.info.license = { name: this.config.license }; }
-        if (this.config.name) { spec.info.title = this.config.name; }
-        if (this.config.version) { spec.info.version = this.config.version; }
         if (this.config.host) { spec.host = this.config.host; }
+
+        if (this.config.hasOwnProperty('info')) {
+            spec.info = this.config.info;
+        } else {
+          if (this.config.description) { spec.info.description = this.config.description; }
+          if (this.config.license) { spec.info.license = { name: this.config.license }; }
+          if (this.config.name) { spec.info.title = this.config.name; }
+          if (this.config.version) { spec.info.version = this.config.version; }
+        }
 
         if (this.config.spec) {
             spec = require('merge').recursive(spec, this.config.spec);


### PR DESCRIPTION
This is a small feature, to allow users to define the swagger info object directly into the `swaggerConfig.json` file.
It comes handy, as some swagger users customise the info object to fit their needs.
However if no info object is defined in the configuration file, the library will generate it as usual, by reading the `package.json` properties.

@thiagobustamante if you like this, please let me know if you want me to:
* describe it in the README
* add unit tests