### PR TITLE
Allow multiple securities

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -147,7 +147,9 @@ class PeopleService {
 
 #### @Security
 
-Add a security constraint to method generated docs, refering the security name from securityDefinitions
+Add a security constraint to method generated docs, referencing the security name from securityDefinitions.
+`@Security` can be used at the controller and method level; if defined on both, method security overwrites controller security.
+Multiple security schemes may be specified to require all of them.
 
 ```typescript
 @Path('people')

--- a/src/metadata/controllerGenerator.ts
+++ b/src/metadata/controllerGenerator.ts
@@ -84,15 +84,10 @@ export class ControllerGenerator {
 
         const securityDecorators = getDecorators(this.node, decorator => decorator.text === 'Security');
         if (!securityDecorators || !securityDecorators.length) { return undefined; }
-        if (securityDecorators.length > 1) {
-            throw new Error(`Only one Security decorator allowed in '${this.node.name.text}' controller.`);
-        }
 
-        const d = securityDecorators[0];
-
-        return {
+        return securityDecorators.map(d => ({
             name: d.arguments[0],
             scopes: d.arguments[1] ? (d.arguments[1] as any).elements.map((e: any) => e.text) : undefined
-        };
+        }));
     }
 }

--- a/src/metadata/metadataGenerator.ts
+++ b/src/metadata/metadataGenerator.ts
@@ -94,7 +94,7 @@ export interface Controller {
     consumes: string[];
     produces: string[];
     tags: string[];
-    security?: Security;
+    security?: Security[];
 }
 
 export interface Method {
@@ -107,7 +107,7 @@ export interface Method {
     type: Type;
     tags: string[];
     responses: ResponseType[];
-    security?: Security;
+    security?: Security[];
     summary?: string;
     consumes: string[];
     produces: string[];

--- a/src/metadata/methodGenerator.ts
+++ b/src/metadata/methodGenerator.ts
@@ -219,16 +219,11 @@ export class MethodGenerator {
     private getMethodSecurity() {
         const securityDecorators = getDecorators(this.node, decorator => decorator.text === 'Security');
         if (!securityDecorators || !securityDecorators.length) { return undefined; }
-        if (securityDecorators.length > 1) {
-            throw new Error(`Only one Security decorator allowed in '${this.getCurrentLocation}' method.`);
-        }
 
-        const d = securityDecorators[0];
-
-        return {
+        return securityDecorators.map(d => ({
             name: d.arguments[0],
             scopes: d.arguments[1] ? (d.arguments[1] as any).elements.map((e: any) => e.text) : undefined
-        };
+        }));
     }
 
     private getInitializerValue(initializer: any) {

--- a/src/swagger/generator.ts
+++ b/src/swagger/generator.ts
@@ -120,9 +120,9 @@ export class SpecGenerator {
         if (method.deprecated) { pathMethod.deprecated = method.deprecated; }
         if (method.tags.length) { pathMethod.tags = method.tags; }
         if (method.security) {
-            const security: any = {};
-            security[method.security.name] = method.security.scopes ? method.security.scopes : [];
-            pathMethod.security = [security];
+            pathMethod.security = method.security.map(s => ({
+                [s.name]: s.scopes || []
+            }));
         }
         this.handleMethodConsumes(method, pathMethod);
 

--- a/test/data/apis.ts
+++ b/test/data/apis.ts
@@ -348,3 +348,28 @@ export class AbstractEntityEndpoint {
         return new NamedEntity();
     }
 }
+
+@Path('secure')
+@swagger.Security('access_token')
+export class SecureEndpoint {
+    @GET
+    get(): string {
+        return 'Access Granted';
+    }
+
+    @POST
+    @swagger.Security('user_email')
+    post(): string {
+        return 'Posted';
+    }
+}
+
+@Path('supersecure')
+@swagger.Security('access_token')
+@swagger.Security('user_email')
+export class SuperSecureEndpoint {
+    @GET
+    get(): string {
+        return 'Access Granted';
+    }
+}

--- a/test/data/swagger.json
+++ b/test/data/swagger.json
@@ -14,6 +14,16 @@
                 "type": "apiKey",
                 "name": "access_token",
                 "in": "query"
+            },
+            "access_token": {
+                "type": "apiKey",
+                "name": "authorization",
+                "in": "header"
+            },
+            "user_email": {
+                "type": "apiKey",
+                "name": "x-user-email",
+                "in": "header"
             }
         },
         "spec": {

--- a/test/unit/definitions.spec.ts
+++ b/test/unit/definitions.spec.ts
@@ -296,4 +296,23 @@ describe('Definition generation', () => {
       expect(expression.evaluate(spec)).to.eq('A numeric identifier');
     });
   });
+
+  describe('SecureEndpoint', () => {
+    it('should apply controller security to request', () => {
+      const expression = jsonata('paths."/secure".get.security');
+      expect(expression.evaluate(spec)).to.deep.equal([ { 'access_token': [] } ]);
+    });
+
+    it('method security should override controller security', () => {
+      const expression = jsonata('paths."/secure".post.security');
+      expect(expression.evaluate(spec)).to.deep.equal([ { 'user_email': [] } ]);
+    });
+  });
+
+  describe('SuperSecureEndpoint', () => {
+    it('should apply two controller securities to request', () => {
+      const expression = jsonata('paths."/supersecure".get.security');
+      expect(expression.evaluate(spec)).to.deep.equal([ { 'access_token': [] }, { 'user_email': [] } ]);
+    });
+  });
 });


### PR DESCRIPTION
This PR allows multiple `@Security` requirements to be specified on a controller or method.

[Spec reference](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#security-requirement-object)