### PR TITLE
Change name of array types from `[]` to `Array`

### DIFF
--- a/src/metadata/resolveType.ts
+++ b/src/metadata/resolveType.ts
@@ -291,7 +291,7 @@ function getAnyTypeName(typeNode: ts.TypeNode): string {
 
     if (typeNode.kind === ts.SyntaxKind.ArrayType) {
         const arrayType = typeNode as ts.ArrayTypeNode;
-        return getAnyTypeName(arrayType.elementType) + '[]';
+        return getAnyTypeName(arrayType.elementType) + 'Array';
     }
 
     if ((typeNode.kind === ts.SyntaxKind.UnionType) || (typeNode.kind === ts.SyntaxKind.AnyKeyword)) {

--- a/test/data/apis.ts
+++ b/test/data/apis.ts
@@ -257,6 +257,10 @@ export class TypeEndpoint {
     }
 }
 
+export interface ResponseBody<T> {
+    data: T;
+}
+
 export class PrimitiveClassModel {
     /**
      * An integer
@@ -316,6 +320,12 @@ export class PrimitiveEndpoint {
     @GET
     getById(@PathParam('id') @swagger.IsLong id: number) {
         // ...
+    }
+
+    @Path('/array')
+    @GET
+    getArray(): ResponseBody<string[]> {
+        return { data: ['hello', 'world'] };
     }
 }
 

--- a/test/unit/definitions.spec.ts
+++ b/test/unit/definitions.spec.ts
@@ -276,6 +276,14 @@ describe('Definition generation', () => {
       expression = jsonata('paths."/primitives/{id}".get.parameters[0].format');
       expect(expression.evaluate(spec)).to.eq('int64');
     });
+
+    it('should generate array type names as type + Array', () => {
+      let expression = jsonata('definitions.ResponseBodystringArray');
+      // tslint:disable-next-line:no-unused-expression
+      expect(expression.evaluate(spec)).to.not.be.undefined;
+      expression = jsonata('paths."/primitives/array".get.responses."200".schema."$ref"');
+      expect(expression.evaluate(spec)).to.equal('#/definitions/ResponseBodystringArray');
+    });
   });
 
   describe('ParameterizedEndpoint', () => {


### PR DESCRIPTION
If the argument of a generic type `ResponseBody<T>` is an array, `ResponseBody<string[]>` is generated as a definition named `ResponseBodystring[]`. However, editor.swagger.io complains that "$ref values must be RFC3986-compliant percent-encoded URIs" because `[` and `]` are reserved characters in RFC3986. Generating the type name as `ResponseBodystringArray` instead fixes this.

As an added benefit, this change also fixes an issue with importing the generated swagger doc into AWS API Gateway, which doesn't accept the `[]` characters.