### PR TITLE
Add StreamFileParam decorator

### DIFF
--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -110,3 +110,26 @@ export function IsFloat(target: any, propertyKey: string, parameterIndex?: numbe
 export function IsDouble(target: any, propertyKey: string, parameterIndex?: number) {
   return;
 }
+
+/**
+ * Creates a mapping between a file on a multipart request and a method
+ * argument.
+ * Unlike @FileParam provided by typescript-rest, this decorator allows to pipe the request.
+ */
+export function StreamFileParam(name: string) {
+    return function (...args: any[]) {
+      return;
+    };
+}
+
+/**
+ * Creates a mapping between multiple files on a multipart request and a method
+ * argument.
+ * Unlike @FileParam provided by typescript-rest, this decorator allows to pipe the request.
+ */
+export function StreamFilesParam(name: string) {
+    return function (...args: any[]) {
+        return;
+    };
+}
+

--- a/src/metadata/parameterGenerator.ts
+++ b/src/metadata/parameterGenerator.ts
@@ -93,7 +93,7 @@ export class ParameterGenerator {
         return {
             description: this.getParameterDescription(parameter),
             in: 'formData',
-            name: getDecoratorTextValue(this.parameter, ident => ident.text === 'FileParam') || parameterName,
+            name: getDecoratorTextValue(this.parameter, ident => ident.text === 'FileParam' || ident.text === 'StreamFileParam') || parameterName,
             parameterName,
             required: !parameter.questionToken,
             type: { typeName: 'file' }
@@ -110,7 +110,7 @@ export class ParameterGenerator {
         return {
             description: this.getParameterDescription(parameter),
             in: 'formData',
-            name: getDecoratorTextValue(this.parameter, ident => ident.text === 'FilesParam') || parameterName,
+            name: getDecoratorTextValue(this.parameter, ident => ident.text === 'FilesParam' || ident.text === 'StreamFilesParam') || parameterName,
             parameterName,
             required: !parameter.questionToken,
             type: { typeName: 'file' }
@@ -259,7 +259,7 @@ export class ParameterGenerator {
         return ['HeaderParam', 'QueryParam', 'Param', 'FileParam',
                 'PathParam', 'FilesParam', 'FormParam', 'CookieParam',
                 'Context', 'ContextRequest', 'ContextResponse', 'ContextNext',
-                'ContextLanguage', 'ContextAccept'].some(d => d === decoratorName);
+                'ContextLanguage', 'ContextAccept', 'StreamFileParam', 'StreamFilesParam'].some(d => d === decoratorName);
     }
 
     private supportPathDataType(parameterType: Type) {

--- a/src/metadata/parameterGenerator.ts
+++ b/src/metadata/parameterGenerator.ts
@@ -31,6 +31,10 @@ export class ParameterGenerator {
                 return this.getFileParameter(this.parameter);
             case 'FilesParam':
                 return this.getFilesParameter(this.parameter);
+            case 'StreamFileParam':
+                return this.getFileParameter(this.parameter);
+            case 'StreamFilesParam':
+                return this.getFilesParameter(this.parameter);
             case 'Context':
             case 'ContextRequest':
             case 'ContextResponse':

--- a/test/data/apis.ts
+++ b/test/data/apis.ts
@@ -339,6 +339,18 @@ export class ParameterizedEndpoint {
     test(@PathParam('objectId') objectId: string): PrimitiveClassModel {
         return new PrimitiveClassModel();
     }
+
+    @Path('/file')
+    @POST
+    file(@FileParam('file') file: Express.Multer.File): PrimitiveClassModel {
+        return new PrimitiveClassModel();
+    }
+
+    @Path('/stream')
+    @POST
+    stream(@swagger.StreamFileParam('stream') file: Express.Multer.File): PrimitiveClassModel {
+        return new PrimitiveClassModel();
+    }
 }
 
 export abstract class Entity {

--- a/test/unit/definitions.spec.ts
+++ b/test/unit/definitions.spec.ts
@@ -298,6 +298,16 @@ describe('Definition generation', () => {
       const expression = jsonata('paths."/parameterized/{objectId}/test".get.parameters[0].in');
       expect(expression.evaluate(spec)).to.eq('path');
     });
+
+    it('should generate formData param for params declared on method', () => {
+        const expression = jsonata('paths."/parameterized/{objectId}/file".post.parameters[0].in');
+        expect(expression.evaluate(spec)).to.eq('formData');
+    });
+
+    it('should generate path param for params declared on class', () => {
+        const expression = jsonata('paths."/parameterized/{objectId}/stream".post.parameters[0].in');
+        expect(expression.evaluate(spec)).to.eq('formData');
+    });
   });
 
   describe('AbstractEntityEndpoint', () => {


### PR DESCRIPTION
In order to be able to pipe the request in express handlers implementations (stream) instead of using multer like typescript-rest is doing with FileParam decorator, the new StreamFileParam decorator will generate the correct swagger button for uploading binary file.