### PR TITLE
Fixing default value for basePath

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -70,7 +70,11 @@ function validateSwaggerConfig(conf: SwaggerConfig): SwaggerConfig {
     conf.name = conf.name || nameDefault;
     conf.description = conf.description || descriptionDefault;
     conf.license = conf.license || licenseDefault;
-    conf.basePath = (conf.basePath !== undefined && conf.basePath) || '/';
+    if (conf.basePath !== undefined) {
+        conf.basePath = conf.basePath
+    } else {
+        conf.basePath = '/'
+    }
     conf.yaml = conf.yaml === false ? false : true;
 
     return conf;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -70,9 +70,7 @@ function validateSwaggerConfig(conf: SwaggerConfig): SwaggerConfig {
     conf.name = conf.name || nameDefault;
     conf.description = conf.description || descriptionDefault;
     conf.license = conf.license || licenseDefault;
-    if (conf.basePath !== undefined) {
-        conf.basePath = conf.basePath
-    } else {
+    if (conf.basePath === undefined) {
         conf.basePath = '/'
     }
     conf.yaml = conf.yaml === false ? false : true;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -70,7 +70,7 @@ function validateSwaggerConfig(conf: SwaggerConfig): SwaggerConfig {
     conf.name = conf.name || nameDefault;
     conf.description = conf.description || descriptionDefault;
     conf.license = conf.license || licenseDefault;
-    conf.basePath = conf.basePath || '/';
+    conf.basePath = (conf.basePath === undefined) || '/';
     conf.yaml = conf.yaml === false ? false : true;
 
     return conf;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -70,7 +70,7 @@ function validateSwaggerConfig(conf: SwaggerConfig): SwaggerConfig {
     conf.name = conf.name || nameDefault;
     conf.description = conf.description || descriptionDefault;
     conf.license = conf.license || licenseDefault;
-    conf.basePath = (conf.basePath === undefined) || '/';
+    conf.basePath = (conf.basePath !== undefined && conf.basePath) || '/';
     conf.yaml = conf.yaml === false ? false : true;
 
     return conf;


### PR DESCRIPTION
I have a problem with typescript-rest and typescript-rest-swagger, it's generating automatically route paths with preceding / ( /path ) even though I am defining @Path('path'). Well that might be ok, but rest-swagger has configuration for basePath, I need to define empty string "", but condition is wrong because this empty string is evaluated as false and default value of "/" is given. So swagger-express-middleware is not working well, because it can't find this as it would need to be //path instead of /path.

This PR should fix the issue.