### PR TITLE
No default value for basePath necessary

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -70,9 +70,6 @@ function validateSwaggerConfig(conf: SwaggerConfig): SwaggerConfig {
     conf.name = conf.name || nameDefault;
     conf.description = conf.description || descriptionDefault;
     conf.license = conf.license || licenseDefault;
-    if (conf.basePath === undefined) {
-        conf.basePath = '/'
-    }
     conf.yaml = conf.yaml === false ? false : true;
 
     return conf;


### PR DESCRIPTION
I am sorry, for creating another PR with this problem. But just found out that basePath: "" with empty value is not valid. It should not be in there at all.