### PR TITLE
Support QueryParam enum. Fix #63

### DIFF
--- a/src/swagger/generator.ts
+++ b/src/swagger/generator.ts
@@ -209,6 +209,8 @@ export class SpecGenerator {
 
         if (parameter.default !== undefined) { swaggerParameter.default = parameter.default; }
 
+        if (parameterType.enum) { swaggerParameter.enum = parameterType.enum; }
+
         return swaggerParameter;
     }
 

--- a/test/data/apis.ts
+++ b/test/data/apis.ts
@@ -20,6 +20,11 @@ interface Person {
     address?: Address;
 }
 
+enum TestEnum {
+    Option1 = 'option1',
+    Option2 = 'option2'
+}
+
 @Accept('text/plain')
 @Path('mypath')
 @swagger.Tags('My Services')
@@ -46,7 +51,8 @@ export class MyService {
     test2(
         @QueryParam('testRequired') test: string,
         @QueryParam('testDefault') test2: string = 'value',
-        @QueryParam('testOptional') test3?: string
+        @QueryParam('testOptional') test3?: string,
+        @QueryParam('testEnum') test4: TestEnum
     ): Person {
         return { name: 'OK' };
     }

--- a/test/unit/definitions.spec.ts
+++ b/test/unit/definitions.spec.ts
@@ -42,6 +42,8 @@ describe('Definition generation', () => {
       expect(expression.evaluate(spec)).to.eq(false);
       expression = jsonata('paths."/mypath/secondpath".get.parameters[2].required');
       expect(expression.evaluate(spec)).to.eq(false);
+      expression = jsonata('paths."/mypath/secondpath".get.parameters[3].enum');
+      expect(expression.evaluate(spec)).to.eql(['option1', 'option2']);
     });
 
     it('should generate description for methods and paraemters', () => {


### PR DESCRIPTION
```ts
enum MyEnum { A = 'a', B = 'b' };
...
@QueryParam('name') name: MyEnum;
...
```
Above code correctly adds `{ enum: ['a', 'b'] }` to query param swagger definition.