### PR TITLE
support tsconfig.json

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -8,7 +8,7 @@ This is a tool to generate swagger files from a [typescript-rest](https://github
 
 **Table of Contents** 
 
-- [Swagger for Typescript-Rest](#)
+- [Swagger for Typescript-rest](#swagger-for-typescript-rest)
   - [Installation](#installation)
   - [Usage](#usage)
     - [Swagger Decorators](#swagger-decorators)
@@ -17,6 +17,7 @@ This is a tool to generate swagger files from a [typescript-rest](https://github
       - [@Tags](#tags)
       - [@Security](#security)
       - [@Produces](#produces)
+      - [@IsInt, @IsLong, @IsFloat, @IsDouble](#isint-islong-isfloat-isdouble)
     - [SwaggerConfig.json](#swaggerconfigjson)
 
 ## Installation
@@ -29,6 +30,8 @@ npm install typescript-rest-swagger -g
 
 ```bash
 swaggerGen -c ./swaggerConfig.json
+swaggerGen -c ./swaggerConfig.json -t # load {cwd}/tsconfig.json
+swaggerGen -c ./swaggerConfig.json -p ./tsconfig.json # load custom tsconfig.json
 ```
 
 Where the [swaggerConfig.json](#swaggerconfigjson) file, contains settings about the swagger generation. For example:
@@ -41,6 +44,21 @@ Where the [swaggerConfig.json](#swaggerconfigjson) file, contains settings about
     }
 }
 ```
+
+Where the [tsconfig.json](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html) file contains compilerOptions. For example:
+
+```json
+{
+    "compilerOptions": {
+        "baseUrl": ".",
+        "paths": {
+            "@/*": ["src/*"]
+        }
+    }
+}
+```
+
+For example above options are required for `swaggerGen` to understand relative imports like `import something from '@/something'`.
 
 ### Swagger Decorators
 

--- a/src/metadata/metadataGenerator.ts
+++ b/src/metadata/metadataGenerator.ts
@@ -9,8 +9,8 @@ export class MetadataGenerator {
     private referenceTypes: { [typeName: string]: ReferenceType } = {};
     private circularDependencyResolvers = new Array<(referenceTypes: { [typeName: string]: ReferenceType }) => void>();
 
-    constructor(entryFile: string) {
-        this.program = ts.createProgram([entryFile], {});
+    constructor(entryFile: string, compilerOptions: ts.CompilerOptions) {
+        this.program = ts.createProgram([entryFile], compilerOptions);
         this.typeChecker = this.program.getTypeChecker();
         MetadataGenerator.current = this;
     }

--- a/test/data/TestInterface.ts
+++ b/test/data/TestInterface.ts
@@ -1,0 +1,4 @@
+export interface TestInterface {
+  a: string;
+  b: number;
+}

--- a/test/data/apis.ts
+++ b/test/data/apis.ts
@@ -10,6 +10,7 @@ import {
 } from 'typescript-rest';
 
 import * as swagger from '../../src/decorators';
+import { TestInterface } from '@/TestInterface'; // to test compilerOptions.paths
 
 interface Address {
     street: string;
@@ -90,6 +91,12 @@ export class MyService {
         @QueryParam('arr') arr: string[] = ['a', 'b', 'c']
     ) {
         return;
+    }
+
+    @POST
+    @Path('test-compiler-options')
+    async testCompilerOptions(payload: TestInterface): Promise<TestInterface> {
+        return { a: 'string', b: 123 };
     }
 }
 


### PR DESCRIPTION
**Current behaviour:**
```js
// tsconfig.json
{
  ...
  "baseUrl": ".",
  "paths": {
    "@/*": ["src/*"]
  },
}
```
```js
// MyController.ts
import { .MyInterface } from '@/MyInterface';
```
Right now `typescript-rest-swagger` throws `No matching model found for referenced type MyInterface`.

**New behaviour:**
* By default `typescript-rest-swagger` will **NOT** try to load tsconfig.json (for backwards compatibility).
* There is new CLI argument `-t / --tsconfig` - it will try to load `{cwd}/tsconfg.json`.
* There is new CLI argument `-p / --tsconfig_path <path>` - it will try to load tsconfig from custom path
* If both above cli args are set then `--tsconfig_path` takes precedence.
