### PR TITLE
fix parsing tsconfig

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -112,7 +112,9 @@ function getCompilerOptions(loadTsconfig: boolean, tsconfigPath?: string | null)
         if (!tsConfig) {
             throw new Error('Invalid tsconfig');
         }
-        return tsConfig.compilerOptions || {};
+        return tsConfig.compilerOptions
+            ? ts.convertCompilerOptionsFromJson(tsConfig.compilerOptions, cwd).options
+            : {};
     } catch (err) {
         if (err.code === 'MODULE_NOT_FOUND') {
             throw Error(`No tsconfig file found at '${tsconfigPath}'`);


### PR DESCRIPTION
@thiagobustamante 
There is a bug in my latest PR (#67 ) regarding using tsconfig compileOptions when parsing ts program. It turned out that options from tsconfig have to be parsed first before passing them to `createProgram`. This PR fixes this with first parsing compile options with `ts.convertCompilerOptionsFromJson(...)`.