### PR TITLE
Improve security decorator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ node_modules
 coverage
 *.log
 npm-debug.log*
-.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules
 coverage
 *.log
 npm-debug.log*
+.idea/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-rest-swagger",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Generate Swagger files from a typescript-rest project",
   "keywords": [
     "typescript",

--- a/src/metadata/controllerGenerator.ts
+++ b/src/metadata/controllerGenerator.ts
@@ -2,7 +2,7 @@ import * as ts from 'typescript';
 import { Controller } from './metadataGenerator';
 import { getSuperClass } from './resolveType';
 import { MethodGenerator } from './methodGenerator';
-import { getDecorators, getDecoratorTextValue } from '../utils/decoratorUtils';
+import {getDecorators, getDecoratorTextValue, parseSecurityDecoratorArguments} from '../utils/decoratorUtils';
 import {normalizePath} from '../utils/pathUtils';
 import * as _ from 'lodash';
 
@@ -79,15 +79,18 @@ export class ControllerGenerator {
     }
 
     private getMethodSecurity() {
-        if (!this.node.parent) { throw new Error('Controller node doesn\'t have a valid parent source file.'); }
-        if (!this.node.name) { throw new Error('Controller node doesn\'t have a valid name.'); }
+        if (!this.node.parent) {
+            throw new Error('Controller node doesn\'t have a valid parent source file.');
+        }
+        if (!this.node.name) {
+            throw new Error('Controller node doesn\'t have a valid name.');
+        }
 
         const securityDecorators = getDecorators(this.node, decorator => decorator.text === 'Security');
-        if (!securityDecorators || !securityDecorators.length) { return undefined; }
+        if (!securityDecorators || !securityDecorators.length) {
+            return undefined;
+        }
 
-        return securityDecorators.map(d => ({
-            name: d.arguments[0],
-            scopes: d.arguments[1] ? (d.arguments[1] as any).elements.map((e: any) => e.text) : undefined
-        }));
+        return securityDecorators.map(parseSecurityDecoratorArguments);
     }
 }

--- a/src/metadata/controllerGenerator.ts
+++ b/src/metadata/controllerGenerator.ts
@@ -2,7 +2,7 @@ import * as ts from 'typescript';
 import { Controller } from './metadataGenerator';
 import { getSuperClass } from './resolveType';
 import { MethodGenerator } from './methodGenerator';
-import {getDecorators, getDecoratorTextValue, parseSecurityDecoratorArguments} from '../utils/decoratorUtils';
+import { getDecorators, getDecoratorTextValue, parseSecurityDecoratorArguments } from '../utils/decoratorUtils';
 import {normalizePath} from '../utils/pathUtils';
 import * as _ from 'lodash';
 

--- a/src/metadata/controllerGenerator.ts
+++ b/src/metadata/controllerGenerator.ts
@@ -79,17 +79,11 @@ export class ControllerGenerator {
     }
 
     private getMethodSecurity() {
-        if (!this.node.parent) {
-            throw new Error('Controller node doesn\'t have a valid parent source file.');
-        }
-        if (!this.node.name) {
-            throw new Error('Controller node doesn\'t have a valid name.');
-        }
+        if (!this.node.parent) { throw new Error('Controller node doesn\'t have a valid parent source file.'); }
+        if (!this.node.name) { throw new Error('Controller node doesn\'t have a valid name.'); }
 
         const securityDecorators = getDecorators(this.node, decorator => decorator.text === 'Security');
-        if (!securityDecorators || !securityDecorators.length) {
-            return undefined;
-        }
+        if (!securityDecorators || !securityDecorators.length) { return undefined; }
 
         return securityDecorators.map(parseSecurityDecoratorArguments);
     }

--- a/src/metadata/metadataGenerator.ts
+++ b/src/metadata/metadataGenerator.ts
@@ -128,7 +128,7 @@ export interface Parameter {
 }
 
 export interface Security {
-    name: string;
+    name?: string;
     scopes?: string[];
 }
 

--- a/src/metadata/methodGenerator.ts
+++ b/src/metadata/methodGenerator.ts
@@ -27,9 +27,7 @@ export class MethodGenerator {
     }
 
     public generate(): Method {
-        if (!this.isValid()) {
-            throw new Error('This isn\'t a valid controller method.');
-        }
+        if (!this.isValid()) { throw new Error('This isn\'t a valid controller method.'); }
 
         const identifier = this.node.name as ts.Identifier;
         const type = resolveType(this.node.type, this.genericTypeMap);
@@ -87,9 +85,7 @@ export class MethodGenerator {
     private processMethodDecorators() {
         const httpMethodDecorators = getDecorators(this.node, decorator => this.supportsPathMethod(decorator.text));
 
-        if (!httpMethodDecorators || !httpMethodDecorators.length) {
-            return;
-        }
+        if (!httpMethodDecorators || !httpMethodDecorators.length) { return; }
         if (httpMethodDecorators.length > 1) {
             throw new Error(`Only one HTTP Method decorator in '${this.getCurrentLocation}' method is acceptable, Found: ${httpMethodDecorators.map(d => d.text).join(', ')}`);
         }
@@ -112,9 +108,7 @@ export class MethodGenerator {
 
     private getMethodResponses(): ResponseType[] {
         const decorators = getDecorators(this.node, decorator => decorator.text === 'Response');
-        if (!decorators || !decorators.length) {
-            return [];
-        }
+        if (!decorators || !decorators.length) { return []; }
 
         return decorators.map(decorator => {
             let description = '';
@@ -154,29 +148,20 @@ export class MethodGenerator {
 
     private getMethodSuccessResponseData(type: Type): ResponseData {
         switch (type.typeName) {
-            case 'void':
-                return {status: '204', type: type};
-            case 'NewResource':
-                return {status: '201', type: type.typeArgument || type};
-            case 'RequestAccepted':
-                return {status: '202', type: type.typeArgument || type};
-            case 'MovedPermanently':
-                return {status: '301', type: type.typeArgument || type};
-            case 'MovedTemporarily':
-                return {status: '302', type: type.typeArgument || type};
+            case 'void': return { status: '204', type: type };
+            case 'NewResource': return { status: '201', type: type.typeArgument || type };
+            case 'RequestAccepted': return { status: '202', type: type.typeArgument || type };
+            case 'MovedPermanently': return { status: '301', type: type.typeArgument || type };
+            case 'MovedTemporarily': return { status: '302', type: type.typeArgument || type };
             case 'DownloadResource':
-            case 'DownloadBinaryData':
-                return {status: '200', type: {typeName: 'buffer'}};
-            default:
-                return {status: '200', type: type};
+            case 'DownloadBinaryData': return { status: '200', type: { typeName: 'buffer' } };
+            default: return { status: '200', type: type };
         }
     }
 
     private getMethodSuccessExamples() {
         const exampleDecorators = getDecorators(this.node, decorator => decorator.text === 'Example');
-        if (!exampleDecorators || !exampleDecorators.length) {
-            return undefined;
-        }
+        if (!exampleDecorators || !exampleDecorators.length) { return undefined; }
         if (exampleDecorators.length > 1) {
             throw new Error(`Only one Example decorator allowed in '${this.getCurrentLocation}' method.`);
         }
@@ -222,9 +207,7 @@ export class MethodGenerator {
 
     private getDecoratorValues(decoratorName: string) {
         const tagsDecorators = getDecorators(this.node, decorator => decorator.text === decoratorName);
-        if (!tagsDecorators || !tagsDecorators.length) {
-            return [];
-        }
+        if (!tagsDecorators || !tagsDecorators.length) { return []; }
         if (tagsDecorators.length > 1) {
             throw new Error(`Only one ${decoratorName} decorator allowed in '${this.getCurrentLocation}' method.`);
         }
@@ -235,9 +218,7 @@ export class MethodGenerator {
 
     private getMethodSecurity() {
         const securityDecorators = getDecorators(this.node, decorator => decorator.text === 'Security');
-        if (!securityDecorators || !securityDecorators.length) {
-            return undefined;
-        }
+        if (!securityDecorators || !securityDecorators.length) { return undefined; }
 
         return securityDecorators.map(parseSecurityDecoratorArguments);
     }

--- a/src/metadata/methodGenerator.ts
+++ b/src/metadata/methodGenerator.ts
@@ -1,10 +1,10 @@
 import * as ts from 'typescript';
-import {Method, ResponseData, ResponseType, Type} from './metadataGenerator';
-import {resolveType} from './resolveType';
-import {ParameterGenerator} from './parameterGenerator';
-import {getJSDocDescription, getJSDocTag, isExistJSDocTag} from '../utils/jsDocUtils';
-import {getDecorators, parseSecurityDecoratorArguments} from '../utils/decoratorUtils';
-import {normalizePath} from '../utils/pathUtils';
+import { Method, ResponseData, ResponseType, Type } from './metadataGenerator';
+import { resolveType } from './resolveType';
+import { ParameterGenerator } from './parameterGenerator';
+import { getJSDocDescription, getJSDocTag, isExistJSDocTag } from '../utils/jsDocUtils';
+import { getDecorators, parseSecurityDecoratorArguments } from '../utils/decoratorUtils';
+import { normalizePath } from '../utils/pathUtils';
 import * as pathUtil from 'path';
 
 export class MethodGenerator {

--- a/src/swagger/generator.ts
+++ b/src/swagger/generator.ts
@@ -122,12 +122,6 @@ export class SpecGenerator {
         if (method.deprecated) { pathMethod.deprecated = method.deprecated; }
         if (method.tags.length) { pathMethod.tags = method.tags; }
         if (method.security) {
-
-            // console.log('CONFIG:', this.config.securityDefinitions);
-            // pathMethod.security = method.security.map(s => ({
-            //     [s.name || 'NOTFOUND']: s.scopes || []
-            // }));
-
             // prepare an empty array for the pathMethod security fields
             pathMethod.security = [];
 

--- a/src/swagger/generator.ts
+++ b/src/swagger/generator.ts
@@ -179,7 +179,6 @@ export class SpecGenerator {
                             throw new Error(`The security decorator on method '${controllerName}.${method.method}' could not find a match for the following scope(s): '${remainingScopes.join(',')}'`);
                         } else if (remainingScopes === requiredScopes) {
                             // if remainingScopes has not been reassigned, this means there were no securityDefinitions defined
-                            // TODO: confirm this logic stands up - assumption might be wrong if _.difference returns the original input at any point
                             throw new Error('There are no securityDefinitions in swagger.config.json, but one or more @Security decorators have been used.');
                         }
                     }

--- a/src/swagger/generator.ts
+++ b/src/swagger/generator.ts
@@ -136,12 +136,12 @@ export class SpecGenerator {
                     if (securityDecoratorInfo.name) {
                         const securityDefinition = this.config.securityDefinitions && this.config.securityDefinitions[securityDecoratorInfo.name];
                         if (!securityDefinition) {
-                            throw new Error(`No such securityDefinition '${securityDecoratorInfo.name}' named on method '${controllerName}.${method.method}'`);
+                            throw new Error(`Unknown securityDefinition '${securityDecoratorInfo.name}' used on method '${controllerName}.${method.method}'`);
                         }
                         // the scopes specified in the securityDecoratorInfo must align with those named in securityDefinitions
                         const missingScopes = _.difference(securityDecoratorInfo.scopes || [], Object.keys(securityDefinition.scopes || {}));
                         if (missingScopes.length > 0) {
-                            throw new Error(`The securityDefinition '${securityDecoratorInfo.name}' named on method '${controllerName}.${method.method}' is missing specified scope(s): '${missingScopes.join(',')}'`);
+                            throw new Error(`The securityDefinition '${securityDecoratorInfo.name}' used on method '${controllerName}.${method.method}' is missing specified scope(s): '${missingScopes.join(',')}'`);
                         }
                         pathMethod.security.push({[securityDecoratorInfo.name]: securityDecoratorInfo.scopes});
 
@@ -180,7 +180,7 @@ export class SpecGenerator {
                         } else if (remainingScopes === requiredScopes) {
                             // if remainingScopes has not been reassigned, this means there were no securityDefinitions defined
                             // TODO: confirm this logic stands up - assumption might be wrong if _.difference returns the original input at any point
-                            throw new Error('The securityDefinitions in swagger.config.json are empty, but one or more @Security decorators are present.');
+                            throw new Error('There are no securityDefinitions in swagger.config.json, but one or more @Security decorators have been used.');
                         }
                     }
                 }

--- a/src/swagger/generator.ts
+++ b/src/swagger/generator.ts
@@ -123,7 +123,7 @@ export class SpecGenerator {
         if (method.tags.length) { pathMethod.tags = method.tags; }
         if (method.security) {
             pathMethod.security = method.security.map(s => ({
-                [s.name]: s.scopes || []
+                [s.name || 'undefined']: s.scopes || []
             }));
         }
         this.handleMethodConsumes(method, pathMethod);

--- a/src/utils/decoratorUtils.ts
+++ b/src/utils/decoratorUtils.ts
@@ -25,9 +25,7 @@ export function parseSecurityDecoratorArguments(decoratorData: DecoratorData): S
 
 export function getDecorators(node: ts.Node, isMatching: (identifier: DecoratorData) => boolean): DecoratorData[] {
     const decorators = node.decorators;
-    if (!decorators || !decorators.length) {
-        return [];
-    }
+    if (!decorators || !decorators.length) { return []; }
 
     return decorators
         .map(d => {
@@ -61,9 +59,7 @@ export function getDecorators(node: ts.Node, isMatching: (identifier: DecoratorD
 
 function getDecorator(node: ts.Node, isMatching: (identifier: DecoratorData) => boolean) {
     const decorators = getDecorators(node, isMatching);
-    if (!decorators || !decorators.length) {
-        return;
-    }
+    if (!decorators || !decorators.length) { return; }
 
     return decorators[0];
 }
@@ -80,7 +76,7 @@ export function getDecoratorTextValue(node: ts.Node, isMatching: (identifier: De
 
 export function getDecoratorOptions(node: ts.Node, isMatching: (identifier: DecoratorData) => boolean) {
     const decorator = getDecorator(node, isMatching);
-    return decorator && typeof decorator.arguments[1] === 'object' ? decorator.arguments[1] as { [key: string]: any } : undefined;
+    return decorator && typeof decorator.arguments[1] === 'object' ? decorator.arguments[1] as {[key: string]: any} : undefined;
 }
 
 export function isDecorator(node: ts.Node, isMatching: (identifier: DecoratorData) => boolean) {


### PR DESCRIPTION
Currently, the @Security decorator as defined in typescript-rest does not match the decorate as defined in typescript-rest-swagger.

This pull request adds support for the @Security decorator as defined in typescript-rest, without breaking support for the decorator as it stands, to maximize backwards compatibility.

Where no name is specified for the @Security decorator (in typescript-rest, this equates to roles(scopes) only) the contents of the swagger.config.json will be used to determine all appropriate matching securityDefinition entries, based on the scopes required.  

Where the name is specified, the behavior is as it was before, albeit with some error checking now in place to ensure that the defined security rule matches something existing in the securityDefinitions.  This could be construed as a breaking change, however for any users affected by this, their resulting swagger.yaml/json would have been invalid regardless.