### PR TITLE
keep the right node_modules directory for resolveTypes

### DIFF
--- a/src/metadata/metadataGenerator.ts
+++ b/src/metadata/metadataGenerator.ts
@@ -28,7 +28,7 @@ export class MetadataGenerator {
         this.program.getSourceFiles().forEach(sf => {
             if (this.ignorePaths && this.ignorePaths.length) {
                 for (const path of this.ignorePaths) {
-                    if(!sf.fileName.includes('node_modules/typescript-rest-swagger/') && mm(sf.fileName, path)) {
+                    if(!sf.fileName.includes('node_modules/typescript-rest/') && mm(sf.fileName, path)) {
                         return;
                     }
                 }


### PR DESCRIPTION
Don't ignore module typescript-swagger instead of modules typescript-rest-swagger for resolveType
to be able to exclude in one line all modules 
"ignore": [
      "**/node_modules/**"
    ]

ignore works but we need to pass all sub directory in node_modules to ignore to avoid ignore the typescript-swagger who contains type NewRessource ....