### PR TITLE
Add @Consumes decorator

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -15,6 +15,7 @@ This is a tool to generate swagger files from a [typescript-rest](https://github
       - [@Response](#response)
       - [@Example](#example)
       - [@Tags](#tags)
+      - [@Consumes](#consumes)
       - [@Produces](#produces)
       - [@IsInt, @IsLong, @IsFloat, @IsDouble](#isint-islong-isfloat-isdouble)
     - [SwaggerConfig.json](#swaggerconfigjson)
@@ -162,6 +163,21 @@ class PeopleService {
 }
 ```
 
+
+#### @Consumes 
+
+Document the consumes property in generated swagger docs
+
+```typescript
+@Path('people')
+@Consumes('text/html')
+class PeopleService {
+  @PUT
+  createPeople(@Param('name') name: string, people: People) {
+     // ...
+  }
+}
+```
 
 #### @Produces 
 

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -67,6 +67,13 @@ export function Tags(...values: Array<string>): any {
 }
 
 /**
+ * Document the method or class comsumes property in generated swagger docs
+ */
+export function Consumes(...values: Array<string>): any {
+  return () => { return; };
+}
+
+/**
  * Document the method or class produces property in generated swagger docs
  */
 export function Produces(...values: Array<string>): any {

--- a/src/metadata/controllerGenerator.ts
+++ b/src/metadata/controllerGenerator.ts
@@ -29,7 +29,7 @@ export class ControllerGenerator extends EndpointGenerator<ts.ClassDeclaration> 
         this.debugger('Controller path: %s', this.pathValue);
 
         const controllerMetadata = {
-            consumes: this.getDecoratorValues('Accept'),
+            consumes: this.getDecoratorValues('Consumes'),
             location: sourceFile.fileName,
             methods: this.buildMethods(),
             name: this.getCurrentLocation(),

--- a/src/metadata/controllerGenerator.ts
+++ b/src/metadata/controllerGenerator.ts
@@ -34,7 +34,7 @@ export class ControllerGenerator extends EndpointGenerator<ts.ClassDeclaration> 
             methods: this.buildMethods(),
             name: this.getCurrentLocation(),
             path: this.pathValue || '',
-            produces: this.getDecoratorValues('Produces'),
+            produces: (this.getDecoratorValues('Produces') ? this.getDecoratorValues('Produces') : this.getDecoratorValues('Accept')),
             responses: this.getResponses(),
             security: this.getSecurity(),
             tags: this.getDecoratorValues('Tags'),

--- a/src/metadata/methodGenerator.ts
+++ b/src/metadata/methodGenerator.ts
@@ -44,7 +44,7 @@ export class MethodGenerator extends EndpointGenerator<ts.MethodDeclaration> {
             name: identifier.text,
             parameters: this.buildParameters(),
             path: this.path,
-            produces: this.getDecoratorValues('Produces'),
+            produces: (this.getDecoratorValues('Produces') ? this.getDecoratorValues('Produces') : this.getDecoratorValues('Accept')),
             responses: responses,
             security: this.getSecurity(),
             summary: getJSDocTag(this.node, 'summary'),

--- a/src/metadata/methodGenerator.ts
+++ b/src/metadata/methodGenerator.ts
@@ -37,7 +37,7 @@ export class MethodGenerator extends EndpointGenerator<ts.MethodDeclaration> {
         const responses = this.mergeResponses(this.getResponses(this.genericTypeMap), this.getMethodSuccessResponse(type));
 
         const methodMetadata = {
-            consumes: this.getDecoratorValues('Accept'),
+            consumes: this.getDecoratorValues('Consumes'),
             deprecated: isExistJSDocTag(this.node, 'deprecated'),
             description: getJSDocDescription(this.node),
             method: this.method,


### PR DESCRIPTION
PR for #29 
 - add `@Consumes` decorator to generate 'consumes' in swagger doc (instead of `@Accept`)
 - take into account of `@Accept` to generate 'produces' if `@Produces` is not specified
 - update README.md