### PR TITLE
Uses enum types to generate spec types

### DIFF
--- a/src/metadata/resolveType.ts
+++ b/src/metadata/resolveType.ts
@@ -163,9 +163,9 @@ function getEnumerateType(typeNode: ts.TypeNode): EnumerateType | undefined {
         const initializer = member.initializer;
         if (initializer) {
             if (initializer.expression) {
-                return initializer.expression.text;
+                return parseEnumValueByKind(initializer.expression.text, initializer.kind);
             }
-            return initializer.text;
+            return parseEnumValueByKind(initializer.text, initializer.kind);
         }
         return;
     }
@@ -175,6 +175,10 @@ function getEnumerateType(typeNode: ts.TypeNode): EnumerateType | undefined {
         }),
         typeName: 'enum',
     } as EnumerateType;
+}
+
+function parseEnumValueByKind (value: string, kind: ts.SyntaxKind): any {
+  return kind === ts.SyntaxKind.NumericLiteral ? parseFloat(value) : value;
 }
 
 function getLiteralType(typeNode: ts.TypeNode): EnumerateType | undefined {
@@ -463,7 +467,7 @@ function getModelTypeProperties(node: any, genericTypes?: Array<ts.TypeNode>): A
     if (node.kind === ts.SyntaxKind.TypeAliasDeclaration) {
         const typeAlias = node as ts.TypeAliasDeclaration;
 
-        return !keywords.includes(typeAlias.type.kind) 
+        return !keywords.includes(typeAlias.type.kind)
             ? getModelTypeProperties(typeAlias.type, genericTypes)
             : [];
     }

--- a/src/swagger/generator.ts
+++ b/src/swagger/generator.ts
@@ -383,7 +383,19 @@ export class SpecGenerator {
     }
 
     private getSwaggerTypeForEnumType(enumType: EnumerateType): Swagger.Schema {
-        return { type: 'string', enum: enumType.enumMembers.map(member => member as string) as [string] };
+        function getDerivedTypeFromValues (values: Array<any>): string {
+          return values.reduce((derivedType: string, item: any) => {
+            const currentType = typeof item;
+            derivedType = derivedType && derivedType !== currentType ? 'string' : currentType;
+            return derivedType;
+          }, null);
+        }
+
+        const enumValues = enumType.enumMembers.map(member => member as string) as [string];
+        return {
+          enum: enumType.enumMembers.map(member => member as string) as [string],
+          type: getDerivedTypeFromValues(enumValues),
+        };
     }
 
     private getSwaggerTypeForReferenceType(referenceType: ReferenceType): Swagger.Schema {

--- a/test/data/apis.ts
+++ b/test/data/apis.ts
@@ -24,6 +24,16 @@ enum TestEnum {
     Option2 = 'option2'
 }
 
+enum TestNumericEnum {
+  Option1,
+  Option2,
+}
+
+enum TestMixedEnum {
+  Option1,
+  Option2 = 'String param',
+}
+
 @Accept('text/plain')
 @Path('mypath')
 @swagger.Tags('My Services')
@@ -51,7 +61,9 @@ export class MyService {
         @QueryParam('testRequired') test: string,
         @QueryParam('testDefault') test2: string = 'value',
         @QueryParam('testOptional') test3?: string,
-        @QueryParam('testEnum') test4?: TestEnum
+        @QueryParam('testEnum') test4?: TestEnum,
+        @QueryParam('testNumericEnum') test5?: TestNumericEnum,
+        @QueryParam('testMixedEnum') test6?: TestMixedEnum
     ): Person {
         return { name: 'OK' };
     }

--- a/test/unit/definitions.spec.ts
+++ b/test/unit/definitions.spec.ts
@@ -51,6 +51,23 @@ describe('Definition generation', () => {
       expect(expression.evaluate(spec)).to.eql(['option1', 'option2']);
     });
 
+    it('should generate specs for enum params based on it values types', () => {
+      let expression = jsonata('paths."/mypath/secondpath".get.parameters[3]');
+      let paramSpec = expression.evaluate(spec);
+      expect(paramSpec.type).to.equal('string');
+      expect(paramSpec.enum).to.eql(['option1', 'option2']);
+
+      expression = jsonata('paths."/mypath/secondpath".get.parameters[4]');
+      paramSpec = expression.evaluate(spec);
+      expect(paramSpec.type).to.equal('number');
+      expect(paramSpec.enum).to.eql([0, 1]);
+
+      expression = jsonata('paths."/mypath/secondpath".get.parameters[5]');
+      paramSpec = expression.evaluate(spec);
+      expect(paramSpec.type).to.equal('string');
+      expect(paramSpec.enum).to.eql([0, 'String param']);
+    });
+
     it('should generate description for methods and parameters', () => {
       let expression = jsonata('paths."/mypath/secondpath".get.parameters[0].description');
       expect(expression.evaluate(spec)).to.eq('This is the test param description');


### PR DESCRIPTION
Closes https://github.com/thiagobustamante/typescript-rest-swagger/issues/93

This PR modified the methods responsible for generating specs for models based on enum objects.

The current version always generates fields based on enums as string, with all options also defined as strings. In this PR, we use the field `kind` to decide its type: If all fields are numbers, this enum will be signed in the swagger definition as number. Otherwise, it will be signed as strings. This implementation also considers mixes types, eg. enums with string and number fields.