### PR TITLE
Added ability to use .js config files

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -29,6 +29,7 @@ npm install typescript-rest-swagger -g
 
 ```bash
 swaggerGen -c ./swaggerConfig.json
+swaggerGen -c ./swaggerConfig.js #.js files are also allowed as config files
 swaggerGen -c ./swaggerConfig.json -t # load {cwd}/tsconfig.json
 swaggerGen -c ./swaggerConfig.json -p ./tsconfig.json # load custom tsconfig.json
 ```

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "clean": "rimraf dist",
     "lint": "tslint ./src/**/*.ts ./test/**/*.ts",
     "lint:fix": "tslint --fix ./src/**/*.ts ./test/**/*.ts -t verbose",
-    "swagger-gen": "node ./dist/cli.js -c ./test/data/swagger.json",
+    "swagger-gen": "node ./dist/cli.js -c ./test/data/swagger.js",
     "pretest": "cross-env NODE_ENV=test npm run build && npm run lint",
     "test": "cross-env NODE_ENV=test mocha --exit",
     "test:coverage": "nyc npm test",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,7 @@ import * as _ from 'lodash';
 import { isAbsolute, join } from 'path';
 import * as ts from 'typescript';
 import * as YAML from 'yamljs';
+import * as path from 'path';
 import { Config, Specification, SwaggerConfig } from './config';
 import { MetadataGenerator } from './metadata/metadataGenerator';
 import { SpecGenerator } from './swagger/generator';
@@ -30,7 +31,7 @@ const parser = new ArgumentParser({
 parser.addArgument(
     ['-c', '--config'],
     {
-        help: 'The swagger config file (swagger.json or swagger.yml).'
+        help: 'The swagger config file (swagger.json or swagger.yml or swaggerCongig.js).'
     }
 );
 
@@ -84,6 +85,8 @@ function getConfig(configPath = 'swagger.json'): Config {
     const configFile = `${workingDir}/${configPath}`;
     if (_.endsWith(configFile, '.yml') || _.endsWith(configFile, '.yaml')) {
         return YAML.load(configFile);
+    } else if (_.endsWith(configFile, '.js')) {
+        return require(path.join(configFile))
     }
     else {
         return fs.readJSONSync(configFile);

--- a/test/data/apis.ts
+++ b/test/data/apis.ts
@@ -7,8 +7,8 @@ import {
     Security
 } from 'typescript-rest';
 
-import { TestInterface } from '@/TestInterface'; // to test compilerOptions.paths
 import * as swagger from '../../src/decorators';
+import { TestInterface } from './TestInterface'; // to test compilerOptions.paths
 
 interface Address {
     street: string;

--- a/test/data/swagger.js
+++ b/test/data/swagger.js
@@ -1,0 +1,37 @@
+module.exports = {
+    "swagger": {
+        "yaml": true,
+        "outputDirectory": "./test/dist",
+        "entryFile": "./test/data/apis.ts",
+        "host": "localhost:3000",
+        "version": "1.0",
+        "name": "Typescript-rest Test API",
+        "description": "a description",
+        "license": "MIT",
+        "basePath": "/v1",
+        "securityDefinitions": {
+            "api_key": {
+                "type": "apiKey",
+                "name": "access_token",
+                "in": "query"
+            },
+            "access_token": {
+                "type": "apiKey",
+                "name": "authorization",
+                "in": "header"
+            },
+            "user_email": {
+                "type": "apiKey",
+                "name": "x-user-email",
+                "in": "header"
+            }
+        },
+        "spec": {
+            "api_key": {
+                "type": "apiKey",
+                "name": "api_key",
+                "in": "header"
+            }
+        }
+    }
+}


### PR DESCRIPTION
In my project I have the need to use .js config files in order to dynamically change the `"ignore"` field. 

This PR addresses that and fixes a small issue within `test/data/apis.ts`



