### PR TITLE
added @Hidden decorator: hide some endpoints from the generated swagg…

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -181,6 +181,22 @@ class PeopleService {
 A Default produces is already created in swagger documentation from the method return analisys. 
 You can use this decorator to override this default produces.
 
+#### @Hidden 
+
+Allow to hide some APIs from swagger docs (ex: test or dev APIs, etc ...).
+This decorator can be applied for a whole class or only a method
+
+```typescript
+@Path('people')
+@Hidden()
+class PeopleService {
+  @GET
+  getPeople(@Param('name') name: string) {
+     // ...
+  }
+}
+```
+
 #### @IsInt, @IsLong, @IsFloat, @IsDouble
 
 Document the type of a `number` property or parameter in generated swagger docs.

--- a/README.MD
+++ b/README.MD
@@ -16,6 +16,7 @@ This is a tool to generate swagger files from a [typescript-rest](https://github
       - [@Example](#example)
       - [@Tags](#tags)
       - [@Produces](#produces)
+      - [@Hidden](#hidden)
       - [@IsInt, @IsLong, @IsFloat, @IsDouble](#isint-islong-isfloat-isdouble)
     - [SwaggerConfig.json](#swaggerconfigjson)
 
@@ -184,7 +185,7 @@ You can use this decorator to override this default produces.
 #### @Hidden 
 
 Allow to hide some APIs from swagger docs (ex: test or dev APIs, etc ...).
-This decorator can be applied for a whole class or only a method
+This decorator can be applied for the whole class or only a single method
 
 ```typescript
 @Path('people')

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -74,6 +74,13 @@ export function Produces(...values: Array<string>): any {
 }
 
 /**
+ * Document the method or class produces property in generated swagger docs
+ */
+export function Hidden(): any {
+  return () => { return; };
+}
+
+/**
  * Document the type of a property or parameter as `integer ($int32)` in generated swagger docs
  */
 export function IsInt(target: any, propertyKey: string, parameterIndex?: number) {

--- a/src/metadata/controllerGenerator.ts
+++ b/src/metadata/controllerGenerator.ts
@@ -1,6 +1,6 @@
 import * as _ from 'lodash';
 import * as ts from 'typescript';
-import { getDecoratorTextValue } from '../utils/decoratorUtils';
+import { getDecoratorTextValue, isDecorator } from '../utils/decoratorUtils';
 import { normalizePath } from '../utils/pathUtils';
 import { EndpointGenerator } from './endpointGenerator';
 import { Controller } from './metadataGenerator';
@@ -64,6 +64,7 @@ export class ControllerGenerator extends EndpointGenerator<ts.ClassDeclaration> 
     private buildMethodsForClass(node: ts.ClassDeclaration, genericTypeMap?: Map<String, ts.TypeNode>) {
         return node.members
             .filter(m => (m.kind === ts.SyntaxKind.MethodDeclaration))
+            .filter(m => !isDecorator(m, decorator => 'Hidden' === decorator.text))
             .map((m: ts.MethodDeclaration) => new MethodGenerator(m, this.pathValue || '', genericTypeMap))
             .filter(generator => {
                 if (generator.isValid() && !this.genMethods.has(generator.getMethodName())) {

--- a/src/metadata/metadataGenerator.ts
+++ b/src/metadata/metadataGenerator.ts
@@ -4,6 +4,7 @@ import * as _ from 'lodash';
 import * as mm from 'minimatch';
 import * as ts from 'typescript';
 import { ControllerGenerator } from './controllerGenerator';
+import { isDecorator } from '../utils/decoratorUtils';
 
 export class MetadataGenerator {
     public static current: MetadataGenerator;
@@ -109,6 +110,7 @@ export class MetadataGenerator {
     private buildControllers() {
         return this.nodes
             .filter(node => node.kind === ts.SyntaxKind.ClassDeclaration)
+            .filter(node => !isDecorator(node, decorator => 'Hidden' === decorator.text))
             .map((classDeclaration: ts.ClassDeclaration) => new ControllerGenerator(classDeclaration))
             .filter(generator => generator.isValid())
             .map(generator => generator.generate());

--- a/src/metadata/metadataGenerator.ts
+++ b/src/metadata/metadataGenerator.ts
@@ -3,8 +3,8 @@ import * as glob from 'glob';
 import * as _ from 'lodash';
 import * as mm from 'minimatch';
 import * as ts from 'typescript';
-import { ControllerGenerator } from './controllerGenerator';
 import { isDecorator } from '../utils/decoratorUtils';
+import { ControllerGenerator } from './controllerGenerator';
 
 export class MetadataGenerator {
     public static current: MetadataGenerator;


### PR DESCRIPTION
PR for #75 
 - add `@Hidden` decorator to hide some endpoints from swagger doc
 - the decorator can be applied for a whole class or a single method
 - update README.md

Note: 
 - I can merge the .filter() in the code but I think it's cleaner that way and we don't care much about performance during the swagger generation IMO.