### PR TITLE
Use cloning for controller.security method

### DIFF
--- a/src/swagger/generator.ts
+++ b/src/swagger/generator.ts
@@ -136,7 +136,7 @@ export class SpecGenerator {
                 method.consumes = _.union(controller.consumes, method.consumes);
                 method.produces = _.union(controller.produces, method.produces);
                 method.tags = _.union(controller.tags, method.tags);
-                method.security = method.security || controller.security;
+                method.security = method.security || { ...controller }.security;
                 method.responses = _.union(controller.responses, method.responses);
                 const pathObject: any = paths[path];
                 pathObject[method.method] = this.buildPathMethod(controller.name, method);


### PR DESCRIPTION
Fix for https://github.com/thiagobustamante/typescript-rest-swagger/issues/141

When using controller.secuirty vs method.security the value should cloned rather than copied. If @Secuirty decorator defined as @Security('*', 'basic') then produced value will be ['*'] - Array, which in case of multiple methods will reference the same internal object.

Without cloning the value, underlying swagger2openapi library fails with S2OError: YAML anchor or merge key.

