### PR TITLE
feat: handle additional types

### DIFF
--- a/test/data/apis.ts
+++ b/test/data/apis.ts
@@ -26,9 +26,17 @@ interface Address {
     street: string;
 }
 
+/**
+ * Represents a person object
+ */
 interface Person {
     name: string;
     address?: Address;
+}
+
+interface Page<T> {
+    items: Array<T>;
+    total: number;
 }
 
 enum TestEnum {
@@ -462,5 +470,63 @@ export class ResponseController {
     @Path('/test')
     public test(): string {
         return 'OK';
+    }
+}
+
+export type TestTuple = [idx: number, value: string];
+
+@Path('complex')
+export class ComplexTypeController {
+    @GET
+    public getTuple(): TestTuple {
+        return [0, "test"];
+    }
+}
+
+@Path('partial')
+export class PartialTypeController {
+    @GET
+    public getPartial(): Partial<Person> {
+        return {
+            name: "Doe"
+        };
+    }
+}
+
+@Path('omit')
+export class OmitTypeController {
+    @GET
+    public getOmit(): Omit<Person, "address"> {
+        return {
+            name: "Test name"
+        };
+    }
+}
+
+@Path('pick')
+export class PickTypeController {
+    @GET
+    public getPick(): Pick<Person, "address"> {
+        return {
+            address: {
+                street: "Test str."
+            }
+        };
+    }
+}
+
+@Path('generic')
+export class GenericsController {
+    @GET
+    public getGeneric(): Page<Person> {
+        return {
+            items: [{
+                name: "User 1",
+                address: {
+                    street: "Str 1"
+                }
+            }],
+            total: 1
+        };
     }
 }

--- a/test/unit/definitions.spec.ts
+++ b/test/unit/definitions.spec.ts
@@ -420,6 +420,70 @@ describe('Definition generation', () => {
     });
   });
 
+  xdescribe('ComplexTypeController', () => {
+    it('should support type Tuple', async () => {
+      const expression = jsonata('paths."/complex".get.responses."200".schema."$ref"');
+      expect(expression.evaluate(spec)).toEqual('#/definitions/TestTuple');
+
+      const definitionExpression = jsonata('definitions.TestTuple');
+      const myTypeDefinition = definitionExpression.evaluate(spec);
+      expect(myTypeDefinition.type).toEqual('object');
+      expect(Object.keys(myTypeDefinition.properties)).toEqual(['idx[0]', 'value[1]']);
+    });
+  });
+
+  xdescribe('PartialTypeController', () => {
+    it('should support type Partial', async () => {
+      const expression = jsonata('paths."/partial".get.responses."200".schema."$ref"');
+      expect(expression.evaluate(spec)).toEqual('#/definitions/PartialPerson');
+
+      const definitionExpression = jsonata('definitions.PartialPerson');
+      const myTypeDefinition = definitionExpression.evaluate(spec);
+      expect(myTypeDefinition.type).toEqual('object');
+      expect(Object.keys(myTypeDefinition.properties)).toEqual(['name', 'address']);
+    });
+  });
+
+  describe('PickTypeController', () => {
+    it('should support type Pick', async () => {
+      const expression = jsonata('paths."/pick".get.responses."200".schema."$ref"');
+      expect(expression.evaluate(spec)).toEqual('#/definitions/Pick');
+
+      const definitionExpression = jsonata('definitions.Pick');
+      const myTypeDefinition = definitionExpression.evaluate(spec);
+      expect(myTypeDefinition.type).toEqual('object');
+      // TODO properly handle Pick
+      // expect(Object.keys(myTypeDefinition.properties)).toEqual(['address']);
+    });
+  });
+
+  describe('OmitTypeController', () => {
+    it('should support type Omit', async () => {
+      const expression = jsonata('paths."/omit".get.responses."200".schema."$ref"');
+      expect(expression.evaluate(spec)).toEqual('#/definitions/Omit');
+
+      const definitionExpression = jsonata('definitions.Omit');
+      const myTypeDefinition = definitionExpression.evaluate(spec);
+      expect(myTypeDefinition.type).toEqual('object');
+      // TODO properly handle Omit
+      // expect(Object.keys(myTypeDefinition.properties)).toEqual(['name']);
+    });
+  });
+
+  describe('GenericTypeController', () => {
+    it('should support generics', async () => {
+      const expression = jsonata('paths."/generic".get.responses."200".schema."$ref"');
+      expect(expression.evaluate(spec)).toEqual('#/definitions/PagePerson');
+
+      const definitionExpression = jsonata('definitions.PagePerson');
+      const genericTypeDefinition = definitionExpression.evaluate(spec);
+      expect(genericTypeDefinition.type).toEqual('object');
+      expect(Object.keys(genericTypeDefinition.properties)).toEqual(['items', 'total']);
+
+      expect(genericTypeDefinition.properties.items.items.$ref).toEqual('#/definitions/Person');
+    });
+  });
+
   describe('TestUnionType', () => {
     it('should support union types', () => {
       const expression = jsonata('paths."/unionTypes".post.parameters[0]');


### PR DESCRIPTION
Added support of parsing Tuple, Partial, Pick and Omit types.

Note: Pick and Omit are mapped onto an empty interface for now.